### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [0.2.0] - 2026-03-23
+
+### Added
+
+#### ARM64 Bundle Script (`scripts/bundle-macos-arm64.sh`)
+- 10-phase build-prep script for Apple Silicon (arm64) — mirrors Intel script structure
+- Phase 5b: ad-hoc codesign of bundled Ruby before first execution (required on ARM64)
+- Re-run safety: Ruby headers restored from system Ruby before Phase 6; symlink `arm64-darwin → arm64-darwin24` created if arch directory mismatch detected
+- Stdlib json conflict fix: removes `json 2.18.0` from bundled Ruby after Phase 3 (superseded by `json 2.19.1` in vendor/bundle; stdlib version lacks `const_defined?` guard causing crash on Rails boot)
+
+### Changed
+
+#### Rails Webapp
+- `sqlite3` gem now uses `force_ruby_platform: true` — forces source compilation instead of prebuilt platform gem (prebuilt has no Ruby 4.0 binaries)
+
+#### Desktop Shell
+- `find_bundled_ruby` searches `resources/ruby/` first (arch-agnostic), then `resources/ruby-{arch}/` (legacy) — both Intel and ARM64 bundles copy to `resources/ruby/`
+- `tauri.conf.json` resources glob updated to `resources/ruby/**/*` (arch-agnostic)
+
+#### CI
+- Resource stubs now include `desktop/resources/ruby/bin/` placeholder to satisfy Tauri glob validation
+
 ## [0.1.0] - 2026-03-15
 
 ### Added

--- a/desktop/src/ruby.rs
+++ b/desktop/src/ruby.rs
@@ -155,6 +155,7 @@ pub(crate) fn build_ruby_env(rails_dir: &Path, ruby_dir: &Path) -> HashMap<Strin
     env.insert("RUBYOPT".to_string(), "-W0".to_string());
     env.insert("LANG".to_string(), "en_US.UTF-8".to_string());
 
+
     env
 }
 

--- a/desktop/src/ruby.rs
+++ b/desktop/src/ruby.rs
@@ -155,7 +155,6 @@ pub(crate) fn build_ruby_env(rails_dir: &Path, ruby_dir: &Path) -> HashMap<Strin
     env.insert("RUBYOPT".to_string(), "-W0".to_string());
     env.insert("LANG".to_string(), "en_US.UTF-8".to_string());
 
-
     env
 }
 

--- a/scripts/bundle-macos-arm64.sh
+++ b/scripts/bundle-macos-arm64.sh
@@ -328,9 +328,35 @@ fi
 # Ensure arm64-darwin is in the lockfile before deployment-mode install.
 bundle lock --add-platform arm64-darwin 2>/dev/null || true
 
-bundle config set --local deployment true
-bundle config set --local path         vendor/bundle
-bundle config set --local without      "development test desktop"
+bundle config set --local deployment        true
+bundle config set --local path             vendor/bundle
+bundle config set --local without          "development test desktop"
+# Prevent precompiled platform gems (e.g. date-arm64-darwin) — they embed
+# `-bundle_loader ruby` which expects symbols from the ruby executable.
+# Our Ruby is --enable-shared; symbols live in libruby.dylib, not the binary.
+# force_ruby_platform ensures every gem is compiled from source using the
+# bundled Ruby's LDSHARED (-dynamic -bundle -undefined dynamic_lookup).
+bundle config set --local force_ruby_platform true
+
+# Remove any already-installed precompiled platform gems so bundle install
+# replaces them with freshly compiled source variants.
+info "Checking for precompiled platform gems (from executable symbols)..."
+PRECOMPILED_REMOVED=0
+while IFS= read -r -d '' bundle_file; do
+  if nm -m "$bundle_file" 2>/dev/null | grep -q "(from executable)"; then
+    gem_dir=$(dirname "$(dirname "$bundle_file")")
+    info "  removing precompiled gem: $(basename "$gem_dir")"
+    rm -rf "$gem_dir"
+    PRECOMPILED_REMOVED=$((PRECOMPILED_REMOVED + 1))
+  fi
+done < <(find "$WEBAPP_DIR/vendor/bundle/ruby/$RUBY_VERSION/gems" \
+         -name "*.bundle" -print0 2>/dev/null)
+if [[ $PRECOMPILED_REMOVED -gt 0 ]]; then
+  info "Removed $PRECOMPILED_REMOVED precompiled gem(s) — will recompile from source"
+  rm -rf "$WEBAPP_DIR/vendor/bundle/ruby/$RUBY_VERSION/extensions"
+fi
+
+bundle lock --add-platform ruby 2>/dev/null || true
 
 info "Running bundle install (may take a minute on first run)..."
 bundle install

--- a/scripts/bundle-macos-x86_64.sh
+++ b/scripts/bundle-macos-x86_64.sh
@@ -220,9 +220,35 @@ header "Phase 6: Vendor Rails gems (bundle install --deployment)"
 
 cd "$WEBAPP_DIR"
 
-bundle config set --local deployment true
-bundle config set --local path         vendor/bundle
-bundle config set --local without      "development test desktop"
+bundle config set --local deployment        true
+bundle config set --local path             vendor/bundle
+bundle config set --local without          "development test desktop"
+# Prevent precompiled platform gems (e.g. date-x86_64-darwin) — they embed
+# `-bundle_loader ruby` which expects symbols from the ruby executable.
+# Our Ruby is --enable-shared; symbols live in libruby.dylib, not the binary.
+# force_ruby_platform ensures every gem is compiled from source using the
+# bundled Ruby's LDSHARED (-dynamic -bundle -undefined dynamic_lookup).
+bundle config set --local force_ruby_platform true
+
+# Remove any already-installed precompiled platform gems so bundle install
+# replaces them with freshly compiled source variants.
+info "Checking for precompiled platform gems (from executable symbols)..."
+PRECOMPILED_REMOVED=0
+while IFS= read -r -d '' bundle_file; do
+  if nm -m "$bundle_file" 2>/dev/null | grep -q "(from executable)"; then
+    gem_dir=$(dirname "$(dirname "$bundle_file")")
+    info "  removing precompiled gem: $(basename "$gem_dir")"
+    rm -rf "$gem_dir"
+    PRECOMPILED_REMOVED=$((PRECOMPILED_REMOVED + 1))
+  fi
+done < <(find "$WEBAPP_DIR/vendor/bundle/ruby/$RUBY_VERSION/gems" \
+         -name "*.bundle" -print0 2>/dev/null)
+if [[ $PRECOMPILED_REMOVED -gt 0 ]]; then
+  info "Removed $PRECOMPILED_REMOVED precompiled gem(s) — will recompile from source"
+  rm -rf "$WEBAPP_DIR/vendor/bundle/ruby/$RUBY_VERSION/extensions"
+fi
+
+bundle lock --add-platform ruby 2>/dev/null || true
 
 info "Running bundle install (may take a minute on first run)..."
 bundle install 2>&1 | tail -5

--- a/webapp/Gemfile.lock
+++ b/webapp/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    ffi (1.17.3)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -216,6 +217,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.1)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.19.1-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.1-aarch64-linux-musl)
@@ -418,6 +422,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin
   arm64-darwin-25
+  ruby
   x86_64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
@@ -492,6 +497,7 @@ CHECKSUMS
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
   ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
   ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
   ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
@@ -528,6 +534,7 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.1) sha256=598b327f36df0b172abd57b68b18979a6e14219353bca87180c31a51a00d5ad3
   nokogiri (1.19.1-aarch64-linux-gnu) sha256=cfdb0eafd9a554a88f12ebcc688d2b9005f9fce42b00b970e3dc199587b27f32
   nokogiri (1.19.1-aarch64-linux-musl) sha256=1e2150ab43c3b373aba76cd1190af7b9e92103564063e48c474f7600923620b5
   nokogiri (1.19.1-arm-linux-gnu) sha256=0a39ed59abe3bf279fab9dd4c6db6fe8af01af0608f6e1f08b8ffa4e5d407fa3

--- a/webapp/db/schema.rb
+++ b/webapp/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_220908) do
+  create_table "posts", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+  end
+end


### PR DESCRIPTION
Force source compilation of native gems in Phase 6 — precompiled platform gems embed -bundle_loader which fails with --enable-shared Ruby. Add force_ruby_platform and precompiled gem detection.